### PR TITLE
Fix tag name compatibility with MDX 3

### DIFF
--- a/docs/design/icons/fontawesome/index.mdx
+++ b/docs/design/icons/fontawesome/index.mdx
@@ -54,7 +54,7 @@ library.add(fab, fas); // Add all icons to the library so you can use them witho
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  icon: FontAwesomeIcon, // Make the FontAwesomeIcon component available in MDX as <icon />.
+  Icon: FontAwesomeIcon, // Make the FontAwesomeIcon component available in MDX as <icon />.
 };
 ```
 
@@ -65,7 +65,7 @@ We can then use the `icon` component in MDX files:
 title: My Doc
 ---
 
-<icon icon="fa-brands fa-github" size="lg" /> This is a GitHub icon.
+<Icon icon="fa-brands fa-github" size="lg" /> This is a GitHub icon.
 ```
 
 ## Using Font Awesome with React

--- a/docs/design/icons/iconify/index.mdx
+++ b/docs/design/icons/iconify/index.mdx
@@ -33,7 +33,7 @@ import { Icon } from '@iconify/react'; // Import the entire Iconify library.
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  icon: Icon, // Make the iconify Icon component available in MDX as <icon />.
+  Icon: Icon, // Make the iconify Icon component available in MDX as <icon />.
 };
 ```
 
@@ -44,7 +44,7 @@ We can then use the `icon` component in MDX files:
 title: My Doc
 ---
 
-<icon icon="mdi:github" height="48" /> This is a GitHub icon.
+<Icon icon="mdi:github" height="48" /> This is a GitHub icon.
 ```
 
 Iconify have a superb [Icon Explorer](https://icon-sets.iconify.design/) where you can search for icons and copy the code to use in your documentation.


### PR DESCRIPTION
From [the docusaurus docs](https://docusaurus.io/docs/next/markdown-features/react):

> From MDX v3+ onward (Docusaurus v3+), lower-case tag names are always rendered as native html elements, and will not use any component mapping you provide.