### PR TITLE
Fix broken FontAwesome docs link and security admonition

### DIFF
--- a/docs/design/icons/fontawesome/index.mdx
+++ b/docs/design/icons/fontawesome/index.mdx
@@ -28,7 +28,7 @@ npm install --save @fortawesome/free-regular-svg-icons @fortawesome/free-brands-
 
 You can add the Pro versions of any Font Awesome packages by [configuring access to the Font Awesome NPM repository](https://fontawesome.com/docs/web/setup/packages.html#configure-access) and installing the appropriate packages (for example `@fortawesome/pro-solid-svg-icons`).
 
-:::security Protect your NPM token
+:::security[Protect your NPM token]
 If you are using a private NPM repository, you should protect your NPM tokens.
 
 If you're using `npm` you should use environment variables along with a `.npmrc` file to store your NPM token. For more information, see [alternate per project setup using environment variable (for NPM)](https://fontawesome.com/docs/web/setup/packages#alternate-per-project-setup-using-environment-variables).
@@ -70,4 +70,4 @@ title: My Doc
 
 ## Using Font Awesome with React
 
-You can use Font Awesome icons in your React components by using the `FontAwesomeIcon` component. Font Awesome have fantastic [React documentation](https://fontawesome.com/how-to-use/on-the-web/using-with/react) that you can use to learn more about using Font Awesome with React components.
+You can use Font Awesome icons in your React components by using the `FontAwesomeIcon` component. Font Awesome have fantastic [React documentation](https://fontawesome.com/docs/web/use-with/react/) that you can use to learn more about using Font Awesome with React components.


### PR DESCRIPTION
Thanks for maintaining this community site! I've found it so useful as I've navigated building a Docusaurus site.

This PR fixes two bugs I noticed on the FontAwesome page 🪲 👷🏼‍♀️ 🔨 
- Broken docs link in the [Using Font Awesome with React](https://docusaurus.community/knowledge/design/icons/fontawesome/#using-font-awesome-with-react) section
- Security admonition in the [Installing Font Awesome](http://localhost:3001/knowledge/design/icons/fontawesome/#installing-font-awesome) section not rendering correctly 

<details><summary>Screenshot - Security admonition after this PR</summary>
<img width="916" alt="Screenshot 2024-02-14 at 18 53 40" src="https://github.com/homotechsual/docusaurus.community/assets/26869552/f974eba1-6bab-4b29-8c22-9491da2f6861">
</details> 

<details><summary>Screenshot - Security admonition currently on prod</summary>
<img width="908" alt="Screenshot 2024-02-14 at 18 57 29" src="https://github.com/homotechsual/docusaurus.community/assets/26869552/bfdf0590-b58a-46d6-916b-6cb2563a57a8">
</details> 

If you'd be interested in implementing a workflow to detect broken links on the site, let me know! I'd be happy to open a follow-up PR.