### PR TITLE
Fix run cmds in serve stage of example dockerfiles

### DIFF
--- a/docs/deployment/docker/_partials/_dockerfile-npm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-npm.mdx
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["npm", "run", "serve", "--host 0.0.0.0", "--no-open"]
+CMD ["npm", "run", "serve", "--host", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy

--- a/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-pnpm.mdx
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["pnpm", "serve", "--host 0.0.0.0", "--no-open"]
+CMD ["pnpm", "serve", "--host", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy

--- a/docs/deployment/docker/_partials/_dockerfile-yarn.mdx
+++ b/docs/deployment/docker/_partials/_dockerfile-yarn.mdx
@@ -36,7 +36,7 @@ FROM prod as serve
 ## Expose the port that Docusaurus will run on.
 EXPOSE 3000
 ## Run the production server.
-CMD ["yarn", "serve", "--host 0.0.0.0", "--no-open"]
+CMD ["yarn", "serve", "--host", "0.0.0.0", "--no-open"]
 
 # Stage 3b: Serve with Caddy.
 FROM caddy:2-alpine as caddy


### PR DESCRIPTION
Hey folks. I was playing around with the docker setup documented here https://docusaurus.community/knowledge/deployment/docker/ and the cmnd's contain a minor mistake.
The current notation would cause:
```
yarn run v1.22.22
$ docusaurus serve '--host 0.0.0.0' --port 8080 --no-open

╭──────────────────────────────────────────────────────────────────────────────╮│                                                                              ││                        Update available 2.4.3 → 3.2.1                        ││                                                                              ││       To upgrade Docusaurus packages with the latest version, run the        ││                             following command:                               ││   `yarn upgrade @docusaurus/core@latest @docusaurus/preset-classic@latest    ││                      @docusaurus/theme-mermaid@latest`                       ││                                                                              │╰──────────────────────────────────────────────────────────────────────────────╯

error: unknown option '--host 0.0.0.0'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```



I would also suggest explaining the necessity of the Caddyfile before "Building the Docker Image" because building the image does not work without having it (if no target is set, or the target is caddy explicitly).


Thanks for the great work! 